### PR TITLE
Sprint 23 fixes :: DoNotMerge until 2025-06-20

### DIFF
--- a/countdown-test-16.txt
+++ b/countdown-test-16.txt
@@ -1,0 +1,3 @@
+Test content for countdown verification
+This PR should not be merged until 5 days from now
+Created at Sun Jun 15 12:50:54 EDT 2025


### PR DESCRIPTION
Testing countdown feature with 5 day delay

This PR should:
1. Show a failing check with countdown
2. Display 'DO NOT MERGE until June 20, 2025' comment
3. Have a label indicating merge restriction
4. Update daily with new countdown
5. Become mergeable on June 20, 2025