### PR TITLE
Independence Day feature - HOLD UNTIL July 4, 2025

### DIFF
--- a/countdown-test-7.txt
+++ b/countdown-test-7.txt
@@ -1,0 +1,3 @@
+Test content for countdown verification
+This PR should not be merged until 19 days from now
+Created at Sun Jun 15 17:53:08 EDT 2025


### PR DESCRIPTION
Testing countdown feature with 19 day delay

This PR should:
1. Show a failing check with countdown
2. Display 'DO NOT MERGE until July 04, 2025' comment
3. Have a label indicating merge restriction
4. Update daily with new countdown
5. Become mergeable on July 04, 2025