### PR TITLE
fix: Critical bug fix - DO NOT MERGE UNTIL June 15, 2025

### DIFF
--- a/edge-case-today.txt
+++ b/edge-case-today.txt
@@ -1,0 +1,4 @@
+Test content for: PR with merge restriction for today (weekend)
+Created at Sun Jun 15 18:02:27 EDT 2025
+
+This file tests: PR with merge restriction for today (weekend)


### PR DESCRIPTION
This PR has a merge restriction for TODAY (Sunday, June 15, 2025).

Expected behavior:
- The restriction date is TODAY
- Since today is Sunday, it might adjust to Monday June 16
- Or it might be considered already valid since the date has arrived
- This tests the edge case of 'merge date = today'